### PR TITLE
feature - add default texture and copyright in the preference window

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -21,7 +21,7 @@ bl_info = {
     "author" : "Otmar Nitsche",
     "description" : "This toolkit prepares your 3D assets to be used for Microsoft Flight Simulator. Copyright (c) 2020 Otmar Nitsche",
     "blender" : (2, 82, 3),
-    "version" : (0, 41, 3),
+    "version" : (0, 41, 4),
     "location" : "View3D",
     "warning" : "This version of the addon is work-in-progress. Don't use it in your active development cycle, as it adds variables and objects to the scene that may cause issues further down the line.",
     "category" : "3D View",

--- a/__init__.py
+++ b/__init__.py
@@ -29,6 +29,7 @@ bl_info = {
 }
 
 import bpy
+from bpy.types import AddonPreferences
 
 from . import auto_load
 
@@ -58,21 +59,13 @@ class addSettingsPanel(bpy.types.AddonPreferences):
         name = "Default Texture Location",
         description = "Default Texture Location",
         default = ""
-      
     )
-
-    
 
     settings_default_copyright: bpy.props.StringProperty (
         name = "Default Copyright Name",
         description = "Default Copyright Name",
         default = ""
-      
     )
-
-    ##bpy.types.Scene.toto = settings_default_copyright
-
-   ## bpy.types.Scene.my_sel_value = bpy.props.StringProperty(name="Sel")
 
     ## draw the panel in the addon preferences
     def draw(self, context):

--- a/__init__.py
+++ b/__init__.py
@@ -55,13 +55,13 @@ auto_load.init()
 class addSettingsPanel(bpy.types.AddonPreferences):
     bl_idname = __package__
  
-    settings_default_texture_location: bpy.props.StringProperty (
+    export_texture_dir: bpy.props.StringProperty (
         name = "Default Texture Location",
         description = "Default Texture Location",
         default = ""
     )
 
-    settings_default_copyright: bpy.props.StringProperty (
+    export_copyright: bpy.props.StringProperty (
         name = "Default Copyright Name",
         description = "Default Copyright Name",
         default = ""
@@ -76,10 +76,10 @@ class addSettingsPanel(bpy.types.AddonPreferences):
         col = box.column(align = True)
 
         ## texture default location
-        col.prop(self, 'settings_default_texture_location', expand=True)
+        col.prop(self, 'export_texture_dir', expand=True)
 
         ## default copyright
-        col.prop(self, 'settings_default_copyright', expand=True)
+        col.prop(self, 'export_copyright', expand=True)
 
 
 def register():

--- a/__init__.py
+++ b/__init__.py
@@ -28,9 +28,6 @@ bl_info = {
     "wiki_url": "https://www.fsdeveloper.com/wiki/index.php?title=Blender2MSFS"
 }
 
-import bpy
-from bpy.types import AddonPreferences
-
 from . import auto_load
 
 from . func_behavior import *
@@ -70,16 +67,18 @@ class addSettingsPanel(bpy.types.AddonPreferences):
     ## draw the panel in the addon preferences
     def draw(self, context):
         layout = self.layout
-        box = layout.box()
 
-        ##row = layout.row()
-        col = box.column(align = True)
+        row = layout.row()
+        row.label(text="Optional - You can set here the default values. This will be used in the export window", icon='INFO')
+
+        box = layout.box()
+        col = box.column(align = False)
 
         ## texture default location
-        col.prop(self, 'export_texture_dir', expand=True)
+        col.prop(self, 'export_texture_dir', expand=False)
 
         ## default copyright
-        col.prop(self, 'export_copyright', expand=True)
+        col.prop(self, 'export_copyright', expand=False)
 
 
 def register():

--- a/__init__.py
+++ b/__init__.py
@@ -28,6 +28,7 @@ bl_info = {
     "wiki_url": "https://www.fsdeveloper.com/wiki/index.php?title=Blender2MSFS"
 }
 
+import bpy
 
 from . import auto_load
 
@@ -49,12 +50,52 @@ from . extensions import *
 
 auto_load.init()
 
+## class to add the preference settings
+class addSettingsPanel(bpy.types.AddonPreferences):
+    bl_idname = __package__
+ 
+    settings_default_texture_location: bpy.props.StringProperty (
+        name = "Default Texture Location",
+        description = "Default Texture Location",
+        default = ""
+      
+    )
+
+    
+
+    settings_default_copyright: bpy.props.StringProperty (
+        name = "Default Copyright Name",
+        description = "Default Copyright Name",
+        default = ""
+      
+    )
+
+    ##bpy.types.Scene.toto = settings_default_copyright
+
+   ## bpy.types.Scene.my_sel_value = bpy.props.StringProperty(name="Sel")
+
+    ## draw the panel in the addon preferences
+    def draw(self, context):
+        layout = self.layout
+        box = layout.box()
+
+        ##row = layout.row()
+        col = box.column(align = True)
+
+        ## texture default location
+        col.prop(self, 'settings_default_texture_location', expand=True)
+
+        ## default copyright
+        col.prop(self, 'settings_default_copyright', expand=True)
+
+
 def register():
     auto_load.register()
     from .extensions import register
     register()
     from .exporter import register
     register()
+    bpy.utils.register_class(addSettingsPanel)
 
     #removed by request of scenery designers.
     #bpy.types.Scene.msfs_guid = bpy.props.StringProperty(name="GUID",default="")
@@ -69,6 +110,7 @@ def unregister():
     #from .exporter import unregister
     #unregister()
     auto_load.unregister()
+    bpy.utils.unregister_class(addSettingsPanel)
 
 def unregister_panel():
     from .extensions import unregister_panel

--- a/exporter/__init__.py
+++ b/exporter/__init__.py
@@ -22,7 +22,6 @@
 #
 ###################################################################################################
 
-import bpy
 
 #from io_scene_gltf2 import *
 
@@ -92,10 +91,6 @@ class ExportExtendedGLTF2_Base:
 
     bl_options = {'PRESET'}
 
-    ## Retrieve preferences settings
-    preferences = bpy.context.preferences
-    addon_prefs = preferences.addons[__package__].preferences
-
     export_format: EnumProperty(
         name='Format',
         items=(('GLB', 'glTF Binary (.glb)',
@@ -126,7 +121,7 @@ class ExportExtendedGLTF2_Base:
     export_copyright: StringProperty(
         name='Copyright',
         description='Legal rights and conditions for the model',
-        default=addon_prefs.settings_default_copyright
+        default=""
     )
 
     export_image_format: EnumProperty(
@@ -148,7 +143,7 @@ class ExportExtendedGLTF2_Base:
     export_texture_dir: StringProperty(
         name='Textures',
         description='Folder to place texture files in. Relative to the .gltf file',
-        default=addon_prefs.settings_default_texture_location,
+        default="",
     )
 
     #############################################
@@ -964,7 +959,16 @@ class ExportExtendedGLTF2(bpy.types.Operator, ExportExtendedGLTF2_Base, ExportHe
 
 
 def menu_func_export(self, context):
-    self.layout.operator(ExportExtendedGLTF2.bl_idname, text='extended glTF 2.0 (.glb/.gltf) for MSFS')
+    # split to get the real addon name
+    name = __name__.split(".")[0]
+    preferences = context.preferences.addons.get(name)
+    op = self.layout.operator(ExportExtendedGLTF2.bl_idname, text='extended glTF 2.0 (.glb/.gltf) for MSFS')
+
+    # if preferences are defined
+    if preferences:
+        addon_prefs = preferences.preferences
+        op.export_copyright = addon_prefs.export_copyright
+        op.export_texture_dir = addon_prefs.export_texture_dir
 
 
 classes = (

--- a/exporter/__init__.py
+++ b/exporter/__init__.py
@@ -92,6 +92,10 @@ class ExportExtendedGLTF2_Base:
 
     bl_options = {'PRESET'}
 
+    ## Retrieve preferences settings
+    preferences = bpy.context.preferences
+    addon_prefs = preferences.addons[__package__].preferences
+
     export_format: EnumProperty(
         name='Format',
         items=(('GLB', 'glTF Binary (.glb)',
@@ -122,7 +126,7 @@ class ExportExtendedGLTF2_Base:
     export_copyright: StringProperty(
         name='Copyright',
         description='Legal rights and conditions for the model',
-        default=''
+        default=addon_prefs.settings_default_copyright
     )
 
     export_image_format: EnumProperty(
@@ -144,7 +148,7 @@ class ExportExtendedGLTF2_Base:
     export_texture_dir: StringProperty(
         name='Textures',
         description='Folder to place texture files in. Relative to the .gltf file',
-        default='',
+        default=addon_prefs.settings_default_texture_location,
     )
 
     #############################################


### PR DESCRIPTION
Hi, 

- added two optional fields in the preference window of the plugin to set the default Texture location and Copyright name
- updated the version number to **0.41.4**

![image](https://user-images.githubusercontent.com/5455001/139588311-5030840f-43d3-46d0-97c7-481b1ba69b51.png)


**Warning** : if you use the Q menu to export, you'll need to remove the 'export to..' and set again. If not, you'll not able to see the changes

Close #4 