### PR TITLE
(feat) Implement Metallic/Roughness scale sliders

### DIFF
--- a/exporter/exp/gltf2_blender_gather_materials_pbr_metallic_roughness.py
+++ b/exporter/exp/gltf2_blender_gather_materials_pbr_metallic_roughness.py
@@ -123,14 +123,43 @@ def __gather_extras(blender_material, export_settings):
     return None
 
 
+def __get_metallic_scale_from_socket(blender_shader_socket: bpy.types.NodeSocket):
+    result = gltf2_blender_search_node_tree.from_socket(
+        blender_shader_socket,
+        gltf2_blender_search_node_tree.FilterByName("metallic_scale_node"))
+    if not result:
+        return None
+    return result[0]
+
 def __gather_metallic_factor(blender_material, export_settings):
     metallic_socket = gltf2_blender_get.get_socket_or_texture_slot(blender_material, "Metallic")
     if metallic_socket is None:
         metallic_socket = gltf2_blender_get.get_socket_or_texture_slot_old(blender_material, "MetallicFactor")
     if isinstance(metallic_socket, bpy.types.NodeSocket) and not metallic_socket.is_linked:
         return metallic_socket.default_value
+    metallic_scale_node = __get_metallic_scale_from_socket(metallic_socket)
+    if metallic_scale_node:
+        return metallic_scale_node.shader_node.inputs[1].default_value
     return None
 
+def __get_roughness_scale_from_socket(blender_shader_socket: bpy.types.NodeSocket):
+    result = gltf2_blender_search_node_tree.from_socket(
+        blender_shader_socket,
+        gltf2_blender_search_node_tree.FilterByName("roughness_scale_node"))
+    if not result:
+        return None
+    return result[0]
+
+def __gather_roughness_factor(blender_material, export_settings):
+    roughness_socket = gltf2_blender_get.get_socket_or_texture_slot(blender_material, "Roughness")
+    if roughness_socket is None:
+        roughness_socket = gltf2_blender_get.get_socket_or_texture_slot_old(blender_material, "RoughnessFactor")
+    if isinstance(roughness_socket, bpy.types.NodeSocket) and not roughness_socket.is_linked:
+        return roughness_socket.default_value
+    roughness_scale_node = __get_roughness_scale_from_socket(roughness_socket)
+    if roughness_scale_node:
+        return roughness_scale_node.shader_node.inputs[1].default_value
+    return None
 
 def __gather_metallic_roughness_texture(blender_material, orm_texture, export_settings):
     if orm_texture is not None:
@@ -156,14 +185,6 @@ def __gather_metallic_roughness_texture(blender_material, orm_texture, export_se
 
     return gltf2_blender_gather_texture_info.gather_texture_info(texture_input, export_settings)
 
-
-def __gather_roughness_factor(blender_material, export_settings):
-    roughness_socket = gltf2_blender_get.get_socket_or_texture_slot(blender_material, "Roughness")
-    if roughness_socket is None:
-        roughness_socket = gltf2_blender_get.get_socket_or_texture_slot_old(blender_material, "RoughnessFactor")
-    if isinstance(roughness_socket, bpy.types.NodeSocket) and not roughness_socket.is_linked:
-        return roughness_socket.default_value
-    return None
 
 def __has_image_node_from_socket(socket):
     result = gltf2_blender_search_node_tree.from_socket(

--- a/func_material.py
+++ b/func_material.py
@@ -191,6 +191,22 @@ def CreatePBRBranch(Material, bsdf_node, offset=(0.0,0.0)):
     metallic_separate = CreateNewNode(Material,'ShaderNodeSeparateRGB',"metallic_sep",location=(offset[0]+550,offset[1]-305))
     metallic_separate.hide = True
 
+     # Roughness scale
+    roughness_scale_node = CreateNewNode(Material,'ShaderNodeMath',"roughness_scale_node",location=(offset[0]+750,offset[1]-355))
+    roughness_scale_node.hide = True
+    roughness_scale_node.operation = 'MULTIPLY'
+    roughness_scale_node.use_clamp = True
+    roughness_scale_node.inputs[1].default_value  = Material.msfs_roughness_scale
+ 
+   # Metallic scale
+    metallic_scale_node = CreateNewNode(Material,'ShaderNodeMath',"metallic_scale_node",location=(offset[0]+750,offset[1]-405))
+    metallic_scale_node.hide = True
+    metallic_scale_node.operation = 'MULTIPLY'
+    metallic_scale_node.use_clamp = True
+    metallic_scale_node.inputs[1].default_value  = Material.msfs_metallic_scale
+
+
+
     # Create a node group for the occlusion map
     #Let's see if the node tree already exists, if not create one.
     occlusion_node_tree = bpy.data.node_groups.get("glTF Settings")
@@ -207,16 +223,19 @@ def CreatePBRBranch(Material, bsdf_node, offset=(0.0,0.0)):
 
     #Link the UV:
     links.new(uv_node.outputs["UV"], texture_metallic_node.inputs["Vector"])
+
     #Create metallic links:
     links.new(texture_metallic_node.outputs["Color"], metallic_detail_mix.inputs["Color1"])
     links.new(metallic_detail_mix.outputs["Color"], metallic_separate.inputs["Image"])
     links.new(metallic_separate.outputs[0], occlusion_group.inputs["Occlusion"])
+    links.new(metallic_separate.outputs[1], roughness_scale_node.inputs[0])
+    links.new(metallic_separate.outputs[2], metallic_scale_node.inputs[0])
     if Material.msfs_metallic_texture != None:
         if Material.msfs_metallic_texture.name != "":
             #link to bsdf
             if (bsdf_node != None and metallic_separate != None):
-                links.new(metallic_separate.outputs[1], bsdf_node.inputs["Roughness"])
-                links.new(metallic_separate.outputs[2], bsdf_node.inputs["Metallic"])
+                links.new(roughness_scale_node.outputs[0], bsdf_node.inputs["Roughness"])
+                links.new(metallic_scale_node.outputs[0], bsdf_node.inputs["Metallic"])
 
 
     # Normal map


### PR DESCRIPTION
Implement the Metallic and Roughness scale sliders.

This is accomplished by adding Math-Multiply nodes between the metallic_sep and bsdf nodes.

Note: This change adds new nodes to the shader graph, it will not update already existing materials.  To use this new feature, a new material will need to be created.

This is my first foray into the Blender API, please let me know if I could have done something a better way.